### PR TITLE
improve slidingwindowattention by chunking

### DIFF
--- a/bio_attention/attention.py
+++ b/bio_attention/attention.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 import math
 
 def compl_mod(m, n):
-    return int(n * math(m/n) - m)   
+    return int(n * math(m/n) - m)
 
 class VanillaSelfAttention(nn.Module):
     def __init__(self):
@@ -47,11 +47,12 @@ class RandomSelfAttention(nn.Module):
         return z
     
 class WindowAttention(nn.Module):
-    def __init__(self, window):
+    def __init__(self, window, dropout=0.1):
         super().__init__()
         assert window % 2 == 1, 'Window size should be an odd integer.'
         
         self.softmax = nn.Softmax(dim = -1)
+        self.dropout = nn.Dropout(dropout)
         self.w = int((window-1)/2)
         
         self.k_ch = window*2
@@ -79,6 +80,7 @@ class WindowAttention(nn.Module):
         mask_value = -torch.finfo(A.dtype).max
         A[:,:].masked_fill_(~self.mask, mask_value)
         A = self.softmax(A)
+        A = self.dropout(A)
 
         z = einsum('b n c q k, b c n h k -> b n c q h', A, v)
         z = z.view(b,nh, -1, h)[:,:,:-pad_q].permute(0,2,1,3)

--- a/bio_attention/attention.py
+++ b/bio_attention/attention.py
@@ -68,12 +68,12 @@ class WindowAttention(nn.Module):
         
         q = q * (h ** -.5)
         
-        pad_q = compl_mod(s, self.q_ch)
-        pad_k = compl_mod((s + self.w*2)-self.k_ch, self.q_ch)
+        q_pad = compl_mod(s, self.q_ch)
+        k_pad = compl_mod((s + self.w*2)-self.k_ch, self.q_ch)
         
-        q = F.pad(k, (0,)*5 + (pad_q,)).unfold(1, self.q_ch, self.q_ch)
-        k = F.pad(k, (0,)*4 + (self.w, self.w + pad_k)).unfold(1, self.k_ch, self.q_ch)
-        v = F.pad(v, (0,)*4 + (self.w, self.w + pad_k)).unfold(1, self.k_ch, self.q_ch)
+        q = F.pad(k, (0,)*5 + (q_pad,)).unfold(1, self.q_ch, self.q_ch)
+        k = F.pad(k, (0,)*4 + (self.w, self.w + k_pad)).unfold(1, self.k_ch, self.q_ch)
+        v = F.pad(v, (0,)*4 + (self.w, self.w + k_pad)).unfold(1, self.k_ch, self.q_ch)
         
         A = einsum('b c n h q, b c n h k -> b n c q k ', q, k)
         

--- a/bio_attention/attention.py
+++ b/bio_attention/attention.py
@@ -55,8 +55,8 @@ class WindowAttention(nn.Module):
         self.dropout = nn.Dropout(dropout)
         self.w = int((window-1)/2)
         
-        self.k_ch = window*2
-        self.q_ch = self.k_ch - window + 1
+        self.k_ch = window * 2
+        self.q_ch = window + 1
         
         u = torch.triu(torch.full((self.q_ch, self.k_ch), True))
         l = torch.tril(torch.full((self.q_ch, self.k_ch), True), self.w*2)
@@ -69,7 +69,7 @@ class WindowAttention(nn.Module):
         q = q * (h ** -.5)
         
         pad_q = compl_mod(s, self.q_ch)
-        pad_k = compl_mod((s + self.w*2), self.q_ch)
+        pad_k = compl_mod((s + self.w*2)-self.k_ch, self.q_ch)
         
         q = F.pad(k, (0,)*5 + (pad_q,)).unfold(1, self.q_ch, self.q_ch)
         k = F.pad(k, (0,)*4 + (self.w, self.w + pad_k)).unfold(1, self.k_ch, self.q_ch)

--- a/bio_attention/attention.py
+++ b/bio_attention/attention.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 import math
 
 def compl_mod(m, n):
-    return int(n * math(m/n) - m)
+    return int(n * math.ceil(m/n) - m)
 
 class VanillaSelfAttention(nn.Module):
     def __init__(self):

--- a/bio_attention/attention.py
+++ b/bio_attention/attention.py
@@ -83,6 +83,6 @@ class WindowAttention(nn.Module):
         A = self.dropout(A)
 
         z = einsum('b n c q k, b c n h k -> b n c q h', A, v)
-        z = z.view(b,nh, -1, h)[:,:,:-pad_q].permute(0,2,1,3)
+        z = z.view(b,nh, -1, h)[:,:,:s].permute(0,2,1,3)
         
         return z


### PR DESCRIPTION
EDIT: also added dropout

Improved computational times for sliding window attention by applying chunking strategy.

`torch.einsum` is currently less efficient in doing many pointwise vector multiplications than doing fewer matrix multiplications, even if the latter involves more calculations. It is better to apply a chunked attention scheme for optimizing computational times.

![image](https://user-images.githubusercontent.com/14290538/206691806-eb4be997-d32c-4817-81e7-3ef9ffe60bc0.png)

Benchmarking results in a ~13x speedup as compared to the previous implementation.

```
import torch
import torch.nn as nn
import math
import torch.nn.functional as F

class WindowAttentionOld(nn.Module):
    def __init__(self, window):
        super().__init__()
        assert window % 2 == 1, 'Window size should be an odd integer.'
        
        self.softmax = nn.Softmax(dim = -2)
        self.w = int((window-1)/2)
    
    def forward(self, q, k, v):
        assert k.shape[1] == q.shape[1], 'q and k should have same input length.'
        b, s, nh, h = k.shape
        
        q = q * (h ** -.5)

        k = F.pad(k, (0,)*4 + (self.w,)*2).unfold(1, s, 1).contiguous()
        v = F.pad(v, (0,)*4 + (self.w,)*2).unfold(dimension=1, size=s, step=1).contiguous()
        # q: B, sql, h, hd       k: B, wl, h, hd, sql
        A = torch.einsum('b q n h, b k n h q -> b q k n', q, k)
        # B, sql, wl, h
        mask = torch.zeros((nh, s), device = k.device).bool()
        mask = F.pad(mask, (self.w,)*2, value = True).unfold(1, s, 1)
        mask = mask.transpose(0,-1).unsqueeze(0)
        
        mask_value = -torch.finfo(A.dtype).max
        A.masked_fill_(mask, mask_value)
        
        A = self.softmax(A)

        z = torch.einsum('b q k n, b k n h q -> b q n h', A, v)
        return z

def compl_mod(m, n):
    return int(n * math.ceil(m/n) - m)   

class WindowAttention(nn.Module):
    def __init__(self, window):
        super().__init__()
        assert window % 2 == 1, 'Window size should be an odd integer.'
        
        self.softmax = nn.Softmax(dim = -1)
        self.w = int((window-1)/2)
        
        self.k_ch = window*2
        self.q_ch = self.k_ch - window + 1
        
        u = torch.triu(torch.full((self.q_ch, self.k_ch), True))
        l = torch.tril(torch.full((self.q_ch, self.k_ch), True), self.w*2)
        self.mask = torch.logical_and(u, l).cuda()
    
    def forward(self, q, k, v):
        assert k.shape[1] == q.shape[1], 'q and k should have same input length.'
        b, s, nh, h = k.shape
        
        q = q * (h ** -.5)
        
        pad_q = compl_mod(s, self.q_ch)
        pad_k = compl_mod((s + self.w*2), self.q_ch)
        
        q = F.pad(k, (0,)*5 + (pad_q,)).unfold(1, self.q_ch, self.q_ch)
        k = F.pad(k, (0,)*4 + (self.w, self.w + pad_k)).unfold(1, self.k_ch, self.q_ch)
        v = F.pad(v, (0,)*4 + (self.w, self.w + pad_q)).unfold(1, self.k_ch, self.q_ch)
        
        A = torch.einsum('b c n h q, b c n h k -> b n c q k ', q, k)
        
        mask_value = -torch.finfo(A.dtype).max
        A[:,:].masked_fill_(~self.mask, mask_value)
        A = self.softmax(A)

        z = torch.einsum('b n c q k, b c n h k -> b n c q h', A, v)
        z = z.view(b,nh, -1, h)[:,:,:-pad_q].permute(0,2,1,3)
        
        return z

class NaiveSlidingAttention(nn.Module):
    def __init__(self, window):
        super().__init__()
        assert window % 2 == 1, 'Window size should be an odd integer.'
        self.softmax = nn.Softmax(dim = -1)
        self.w = int((window-1)/2)
        
    def forward(self, q, k, v):
        assert k.shape[1] == q.shape[1], 'q and k should have same input length.'
        b, s, nh, h = k.shape
        
        q = q * (h ** -.5)
        
        A = torch.einsum('b i n h, b j n h -> b n i j', q, k)
        u_ = torch.triu(torch.full(A.shape[2:], True), -self.w+1)
        l_ = torch.tril(torch.full(A.shape[2:], True), self.w)
        mask_ = torch.logical_and(u_, l_).cuda()
        A[:,:].masked_fill_(~mask_, -torch.finfo(A.dtype).max)
        A = self.softmax(A)

        z = torch.einsum('b n i j, b i n h -> b n i h', A, v)
        return z

q = torch.randn(40, 500, 8, 16).cuda()
k = torch.randn(40, 500, 8, 16).cuda()
v = torch.randn(40, 500, 8, 16).cuda()
```
```
%%timeit
model = NaiveSlidingAttention(201).cuda()
out = model(q, k, v)
# ~2.5 ms
```
```
%%timeit
model = WindowAttention(201).cuda()
out = model(q, k, v)
# ~3.58 ms
```

```
%%timeit
model = WindowAttentionOld(201).cuda()
out = model(q, k, v)
# ~50 ms
```


